### PR TITLE
kubernetes: do not sudo to install via kubeadm

### DIFF
--- a/k8s-kubernetes.yaml
+++ b/k8s-kubernetes.yaml
@@ -36,7 +36,6 @@
 
 - name: Configure Kubernetes Master
   hosts: master
-  become: true
   vars:
     ansible_user: mchellmer
   tasks:

--- a/k8s-kubernetes.yaml
+++ b/k8s-kubernetes.yaml
@@ -106,7 +106,7 @@
 
   handlers:
     - name: Reload shell
-      shell: source /home/{{ ansible_user }}/.bashrc
+      shell: . /home/{{ ansible_user }}/.bashrc
       ignore_errors: yes
 
 - name: Join Kubernetes master to worker nodes


### PR DESCRIPTION
- ensure ansible does not become sudo when configuring kubernetes - it causes permissions issues when interacting with the console
- update kubeconfig setup for raspbian